### PR TITLE
Update bindgen to fix building with clang 16

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,4 @@ rayon = "1.6.1"
 serial_test = "1.0.0"
 
 [build-dependencies]
-bindgen = "0.59.1"
+bindgen = "0.68.1"

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ fn main() {
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
         .parse_callbacks(Box::new(ignored_macros))
-        .rustfmt_bindings(true)
+        .formatter(bindgen::Formatter::Rustfmt)
         .generate() // Finish the builder and generate the bindings.
         .expect("unable to generate bindings");
 


### PR DESCRIPTION
https://github.com/rust-lang/rust-bindgen/pull/2319

Also replaces now deprecated `rustfmt_bindings` call: https://docs.rs/bindgen/latest/bindgen/struct.Builder.html#method.rustfmt_bindings